### PR TITLE
Fix JSON unmarshal error for Agendapunt.Nummer field

### DIFF
--- a/etl/internal/models/models.go
+++ b/etl/internal/models/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -157,6 +158,18 @@ func (csn *CustomStringNumber) Scan(value interface{}) error {
 		return nil
 	case []byte:
 		csn.StringValue = string(v)
+		csn.Valid = true
+		return nil
+	case int64:
+		csn.StringValue = strconv.FormatInt(v, 10)
+		csn.Valid = true
+		return nil
+	case float64:
+		if v == float64(int64(v)) {
+			csn.StringValue = fmt.Sprintf("%.0f", v)
+		} else {
+			csn.StringValue = fmt.Sprintf("%g", v)
+		}
 		csn.Valid = true
 		return nil
 	default:


### PR DESCRIPTION
Changed Agendapunt.Nummer type from *int64 to *CustomStringNumber to handle API responses that return string values instead of numbers. This uses the existing CustomStringNumber type which can unmarshal both string and numeric JSON values, similar to how Kamerstukdossier.Nummer is handled.

Fixes: json: cannot unmarshal string into Go struct field Agendapunt.Besluit.Agendapunt.Nummer of type int64